### PR TITLE
add `meta` and `version` to `gcmarray` struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.jl.cov
 *.jl.*.cov
 *.jl.mem

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,44 +4,24 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
+  - 1.2
   - nightly
 notifications:
   email: false
-git:
-  depth: 99999999
 
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - julia: nightly
-
-## uncomment and modify the following lines to manually install system packages
-#addons:
-#  apt: # apt-get for linux
-#    packages:
-#    - gfortran
-#before_script: # homebrew for mac
-#  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc; fi
-
-## uncomment the following lines to override the default test script
-#script:
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("GCMFaces"); Pkg.test("GCMFaces"; coverage=true)'
 after_success:
-  # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("GCMFaces")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("GCMFaces")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
 
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.0
-      os: linux
+      julia: 1.3
       script:
-        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
-                                               Pkg.instantiate()'
+        - julia --project=docs/ -e 'using Pkg; Pkg.instantiate();
+                                    Pkg.develop(PackageSpec(path=pwd()))'
         - julia --project=docs/ docs/make.jl
       after_success: skip
+  allow_failures:
+    - julia: nightly

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -9,6 +9,15 @@ git-tree-sha1 = "23d1f1e10d4e24374112fcf800ac981d14a54b24"
 uuid = "81a5f4ea-a946-549a-aa7e-2a7f63a27d31"
 version = "1.0.0"
 
+[[ConstructionBase]]
+git-tree-sha1 = "a2a6a5fea4d6f730ec4c18a76d27ec10e8ec1c50"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.0.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -16,6 +25,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -31,13 +43,24 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -57,5 +80,15 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Unitful]]
+deps = ["ConstructionBase", "LinearAlgebra", "Random"]
+git-tree-sha1 = "0b95bcc0745541528ff3a95b722367e6cc12f43e"
+uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
+version = "1.0.0"

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,15 @@ version = "0.2.6"
 
 [deps]
 CatViews = "81a5f4ea-a946-549a-aa7e-2a7f63a27d31"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 CatViews = "1.0"
+Unitful = "1.0"
 julia = "^1.0"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeshArrays"
 uuid = "cb8c808f-1acf-59a3-9d2b-6e38d009f683"
 authors = ["gaelforget <gforget@mit.edu>"]
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 CatViews = "81a5f4ea-a946-549a-aa7e-2a7f63a27d31"

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ The example below (1) generates a grid decomposition, (2) seeds random noise eve
 
 ```
 using MeshArrays; p=dirname(pathof(MeshArrays))
-GridVariables=GridOfOnes("PeriodicDomain",16,20)
+γ,Γ=GridOfOnes("PeriodicDomain",16,20)
 
 include(joinpath(p,"../examples/Demos.jl"))
-(in,out,_,_)=demo2(GridVariables);
-show(out)
+(xi,xo,_,_)=demo2(Γ);
+show(xo)
 
 using Plots; plotlyjs()
 include(joinpath(p,"../examples/Plots.jl"))
-heatmap(out,clims=(-0.25,0.25))
+heatmap(xo,clims=(-0.25,0.25))
 ```
 
 Initial noise           |  Smoothed noise 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,15 +31,15 @@ Examples below (1) generate a grid configuration, (2) seed a 2D field of random 
 
 ```
 using MeshArrays; p=dirname(pathof(MeshArrays))
-GridVariables=GridOfOnes("PeriodicDomain",16,20)
+γ,Γ=GridOfOnes("PeriodicDomain",16,20)
 
 include(joinpath(p,"../examples/Demos.jl"))
-(in,out,_,_)=demo2(GridVariables);
-show(out)
+(xi,xo,_,_)=demo2(Γ);
+show(xo)
 
 using Plots; plotlyjs()
 include(joinpath(p,"../examples/Plots.jl"))
-heatmap(out,clims=(-0.25,0.25))
+heatmap(xo,clims=(-0.25,0.25))
 ```
 
 Grid scale noise           |  Smoothed noise
@@ -49,8 +49,8 @@ Grid scale noise           |  Smoothed noise
 **[B]** _6 subdomains_, with _100x100 points_ each, covering the _six faces of a cube_
 
 ```
-GridVariables=GridOfOnes("CubeSphere",6,100)
-DemoVariables=demo2(GridVariables)
+γ,Γ=GridOfOnes("CubeSphere",6,100)
+D=demo2(Γ)
 ```
 
 **[C]** Global Model Grid with _5 uneven subdomains_, _variable spacing_, & _continents_
@@ -58,12 +58,10 @@ DemoVariables=demo2(GridVariables)
 _This requires downloading a pre-defined [global ocean grid](http://www.geosci-model-dev.net/8/3071/2015/) from the [MITgcm community](https://mitgcm.readthedocs.io/en/latest/)._
 
 ```
-git clone https://github.com/gaelforget/GRID_LLC90
-GridVariables=GridLoad(GridSpec("LatLonCap","GRID_LLC90/"))
-show(GridVariables["Depth"])
-
-DemoVariables=demo2(GridVariables)
-heatmap(out,clims=(-0.25,0.25))
+#run(`git clone https://github.com/gaelforget/GRID_LLC90`)
+Γ=GridLoad(GridSpec("LatLonCap","GRID_LLC90/"))
+D=demo2(Γ)
+heatmap(D[2],clims=(-0.25,0.25))
 ```
 
 ## Earth Model Grids

--- a/examples/Benchmarks.jl
+++ b/examples/Benchmarks.jl
@@ -59,20 +59,20 @@ cd("/Users/gforget/mywork/data/")
 #
 # This uses `demo3` to test indexing type operations.
 
-mygrid=GridSpec("LatLonCap","GRID_LLC90/")
-GridVariables=GridLoad(mygrid)
-TrspX=mygrid.read(mygrid.path*"TrspX.bin",MeshArray(mygrid,Float32))
-TrspY=mygrid.read(mygrid.path*"TrspY.bin",MeshArray(mygrid,Float32))
-TauX=mygrid.read(mygrid.path*"TauX.bin",MeshArray(mygrid,Float32))
-TauY=mygrid.read(mygrid.path*"TauY.bin",MeshArray(mygrid,Float32))
-SSH=mygrid.read(mygrid.path*"SSH.bin",MeshArray(mygrid,Float32))
-(UV, LC, Tr)=demo3(TrspX,TrspY,GridVariables);
+γ=GridSpec("LatLonCap","GRID_LLC90/")
+Γ=GridLoad(γ)
+TrspX=γ.read(γ.path*"TrspX.bin",MeshArray(γ,Float32))
+TrspY=γ.read(γ.path*"TrspY.bin",MeshArray(γ,Float32))
+TauX=γ.read(γ.path*"TauX.bin",MeshArray(γ,Float32))
+TauY=γ.read(γ.path*"TauY.bin",MeshArray(γ,Float32))
+SSH=γ.read(γ.path*"SSH.bin",MeshArray(γ,Float32))
+(UV, LC, Tr)=demo3(TrspX,TrspY,Γ);
 
-@btime GridVariables=GridLoad(mygrid)
-@btime mygrid.read(mygrid.path*"TrspX.bin",MeshArray(mygrid,Float32))
-@btime LC=LatitudeCircles(-89.0:89.0,GridVariables)
-@btime for i=1:length(LC); ThroughFlow(UV,LC[i],GridVariables); end
-@btime (UV, LC, Tr)=demo3(TrspX,TrspY,GridVariables);
+@btime Γ=GridLoad(γ)
+@btime γ.read(γ.path*"TrspX.bin",MeshArray(γ,Float32))
+@btime LC=LatitudeCircles(-89.0:89.0,Γ)
+@btime for i=1:length(LC); ThroughFlow(UV,LC[i],Γ); end
+@btime (UV, LC, Tr)=demo3(TrspX,TrspY,Γ);
 
 # **2019/08/08**
 # ```

--- a/examples/Benchmarks.jl
+++ b/examples/Benchmarks.jl
@@ -44,10 +44,10 @@ cd("/Users/gforget/mywork/data/")
 #
 # This uses `demo2 / smooth` as done in `2018/09` to test exchanges and array operations.
 
-GridVariables=GridOfOnes("CubeSphere",6,100);
-(Rini,Rend,DXCsm,DYCsm)=demo2(GridVariables);
-@btime (dFLDdx, dFLDdy)=gradient(Rini,GridVariables);
-@btime Rend=smooth(Rini,DXCsm,DYCsm,GridVariables);
+γ,Γ=GridOfOnes("CubeSphere",6,100);
+(Rini,Rend,DXCsm,DYCsm)=demo2(Γ);
+@btime (dFLDdx, dFLDdy)=gradient(Rini,Γ);
+@btime Rend=smooth(Rini,DXCsm,DYCsm,Γ);
 
 # **2019/08/08**
 # ```

--- a/examples/Demos.jl
+++ b/examples/Demos.jl
@@ -15,9 +15,9 @@ etc.). Call sequence:
 """
 function demo1(gridChoice::String,GridParentDir="./")
 
-    mygrid=GridSpec(gridChoice,GridParentDir)
+    γ=GridSpec(gridChoice,GridParentDir)
 
-    D=mygrid.read(mygrid.path*"Depth.data",MeshArray(mygrid,mygrid.ioPrec))
+    D=γ.read(γ.path*"Depth.data",MeshArray(γ,γ.ioPrec))
 
     1000 .+ D
     D .+ 1000
@@ -33,18 +33,18 @@ function demo1(gridChoice::String,GridParentDir="./")
     D/D
 
     Dexch=exchange(D,4)
-    Darr=mygrid.write(D)
-    DD=mygrid.read(Darr,D)
+    Darr=γ.write(D)
+    DD=γ.read(Darr,D)
     DD .== D
 
-    GridVariables=GridLoad(mygrid)
+    Γ=GridLoad(γ)
 
-    (dFLDdx, dFLDdy)=gradient(GridVariables["YC"],GridVariables)
+    (dFLDdx, dFLDdy)=gradient(Γ["YC"],Γ)
     (dFLDdxEx,dFLDdyEx)=exchange(dFLDdx,dFLDdy,4)
 
-    H=GridVariables["hFacC"]
-    Ha=mygrid.write(H)
-    Hb=mygrid.read(Ha,H)
+    H=Γ["hFacC"]
+    Ha=γ.write(H)
+    Hb=γ.read(Ha,H)
 
     println(typeof(H))
     println(size(H))
@@ -87,33 +87,33 @@ function demo2()
     (Rini,Rend,DXCsm,DYCsm)=demo2(Γ)
 end
 
-function demo2(GridVariables::Dict)
+function demo2(Γ::Dict)
 
-    mygrid=GridVariables["XC"].grid
+    γ=Γ["XC"].grid
 
     #initialize 2D field of random numbers
-    tmp1=randn(Float32,Tuple(mygrid.ioSize))
-    Rini=mygrid.read(tmp1,MeshArray(mygrid,Float32))
+    tmp1=randn(Float32,Tuple(γ.ioSize))
+    Rini=γ.read(tmp1,MeshArray(γ,Float32))
 
     #apply land mask
-    if ndims(GridVariables["hFacC"].f[1])>2
-        tmp1=mask(view(GridVariables["hFacC"],:,:,1),NaN,0)
-    elseif ndims(GridVariables["hFacC"].f)>1
-        #tmp1=mask(view(GridVariables["hFacC"],:,1),NaN,0)
+    if ndims(Γ["hFacC"].f[1])>2
+        tmp1=mask(view(Γ["hFacC"],:,:,1),NaN,0)
+    elseif ndims(Γ["hFacC"].f)>1
+        #tmp1=mask(view(Γ["hFacC"],:,1),NaN,0)
         tmp1=similar(Rini)
-        for i=1:length(tmp1.fIndex); tmp1[i]=GridVariables["hFacC"][i,1]; end;
+        for i=1:length(tmp1.fIndex); tmp1[i]=Γ["hFacC"][i,1]; end;
         tmp1=mask(tmp1,NaN,0)
     else
-        tmp1=mask(GridVariables["hFacC"],NaN,0)
+        tmp1=mask(Γ["hFacC"],NaN,0)
     end
     msk=fill(1.,tmp1) + 0. *tmp1;
     Rini=msk*Rini;
 
     #specify smoothing length scales in x, y directions
-    DXCsm=3*GridVariables["DXC"]; DYCsm=3*GridVariables["DYC"];
+    DXCsm=3*Γ["DXC"]; DYCsm=3*Γ["DYC"];
 
     #apply smoother
-    Rend=smooth(Rini,DXCsm,DYCsm,GridVariables);
+    Rend=smooth(Rini,DXCsm,DYCsm,Γ);
 
     return (Rini,Rend,DXCsm,DYCsm)
 
@@ -136,29 +136,29 @@ heatmap(1e-6*UV["V"],title="V comp. in Sv",clims=(-10,10))
 """
 function demo3()
 
-    mygrid=GridSpec("LatLonCap","GRID_LLC90/")
-    GridVariables=GridLoad(mygrid)
+    γ=GridSpec("LatLonCap","GRID_LLC90/")
+    Γ=GridLoad(γ)
 
-    TrspX=mygrid.read(mygrid.path*"TrspX.bin",MeshArray(mygrid,Float32))
-    TrspY=mygrid.read(mygrid.path*"TrspY.bin",MeshArray(mygrid,Float32))
-    TauX=mygrid.read(mygrid.path*"TauX.bin",MeshArray(mygrid,Float32))
-    TauY=mygrid.read(mygrid.path*"TauY.bin",MeshArray(mygrid,Float32))
-    SSH=mygrid.read(mygrid.path*"SSH.bin",MeshArray(mygrid,Float32))
+    TrspX=γ.read(γ.path*"TrspX.bin",MeshArray(γ,Float32))
+    TrspY=γ.read(γ.path*"TrspY.bin",MeshArray(γ,Float32))
+    TauX=γ.read(γ.path*"TauX.bin",MeshArray(γ,Float32))
+    TauY=γ.read(γ.path*"TauY.bin",MeshArray(γ,Float32))
+    SSH=γ.read(γ.path*"SSH.bin",MeshArray(γ,Float32))
 
-    (UV, LC, Tr)=demo3(TrspX,TrspY,GridVariables)
+    (UV, LC, Tr)=demo3(TrspX,TrspY,Γ)
 
 end
 
-function demo3(U::MeshArray,V::MeshArray,GridVariables::Dict)
+function demo3(U::MeshArray,V::MeshArray,Γ::Dict)
 
-    LC=LatitudeCircles(-89.0:89.0,GridVariables)
+    LC=LatitudeCircles(-89.0:89.0,Γ)
 
     #UV=Dict("U"=>U,"V"=>V,"dimensions"=>["x","y","z","t"],"factors"=>["dxory","dz"])
     UV=Dict("U"=>U,"V"=>V,"dimensions"=>["x","y"])
 
     Tr=Array{Float64,1}(undef,length(LC));
     for i=1:length(LC)
-       Tr[i]=ThroughFlow(UV,LC[i],GridVariables)
+       Tr[i]=ThroughFlow(UV,LC[i],Γ)
     end
 
     return UV, LC, Tr

--- a/examples/Demos.jl
+++ b/examples/Demos.jl
@@ -82,9 +82,9 @@ heatmap(Rini,title="raw noise",clims=(-0.5,0.5))
 function demo2()
 
     #Pre-requisite: either load predefined grid using `demo1` or call `GridOfOnes`
-    isdir("GRID_LLC90") ? GridVariables=GridLoad(GridSpec("LatLonCap","GRID_LLC90/")) : GridVariables=GridOfOnes("CubeSphere",6,100)
+    isdir("GRID_LLC90") ? Γ=GridLoad(GridSpec("LatLonCap","GRID_LLC90/")) : (γ,Γ)=GridOfOnes("CubeSphere",6,100)
 
-    (Rini,Rend,DXCsm,DYCsm)=demo2(GridVariables)
+    (Rini,Rend,DXCsm,DYCsm)=demo2(Γ)
 end
 
 function demo2(GridVariables::Dict)

--- a/src/Exchanges.jl
+++ b/src/Exchanges.jl
@@ -95,7 +95,7 @@ fillval=0.0
 
 ni,nj=Int.(transpose(fld.grid.ioSize)./fld.grid.fSize[1])
 s=fld.fSize
-FLD=similar(fld);
+FLD=similar(fld;m=fld.meta);
 
 for i=1:ni
   for j=1:nj
@@ -154,8 +154,8 @@ fillval=0.0
 
 ni,nj=Int.(transpose(fldU.grid.ioSize)./fldU.grid.fSize[1])
 s=fldU.fSize
-FLDU=similar(fldU)
-FLDV=similar(fldV)
+FLDU=similar(fldU;m=fldU.meta)
+FLDV=similar(fldV;m=fldV.meta)
 
 for i=1:ni
   for j=1:nj
@@ -196,7 +196,7 @@ fillval=0.0
 #step 1
 
 s=size.(fld.f);
-FLD=similar(fld);
+FLD=similar(fld;m=fld.meta);
 FLD.f[1]=fill(fillval,s[1].+2N);
 @views FLD.f[1][N+1:N+s[1][1],N+1:N+s[1][2]]=fld.f[1];
 
@@ -233,8 +233,8 @@ fillval=0.0
 #step 1
 
 s=size.(fldU.f);
-FLDU=similar(fldU);
-FLDV=similar(fldV);
+FLDU=similar(fldU;m=fldU.meta);
+FLDV=similar(fldV;m=fldV.meta);
 
 FLDU.f[1]=fill(fillval,s[1][1]+1,s[1][2]);
 FLDV.f[1]=fill(fillval,s[1][1],s[1][2]+1);
@@ -263,7 +263,7 @@ s=size.(fld.f)
 nf=fld.grid.nFaces
 nf==5 ? s=vcat(s,s[3]) : nothing
 tp=fld.grid.class
-FLD=similar(fld)
+FLD=similar(fld;m=fld.meta)
 
 for i=1:nf; FLD.f[i]=fill(fillval,s[i].+2N); end;
 #code below yields strange, seemingly incorrect results:
@@ -311,8 +311,8 @@ s=size.(fldU.f)
 nf=fldU.grid.nFaces
 nf==5 ? s=vcat(s,s[3]) : nothing
 tp=fldU.grid.class
-FLDU=similar(fldU)
-FLDV=similar(fldV)
+FLDU=similar(fldU;m=fldU.meta)
+FLDV=similar(fldV;m=fldV.meta)
 
 for i=1:nf;
  FLDU.f[i]=fill(fillval,s[i].+2N);
@@ -365,8 +365,8 @@ s=size.(fldU.f)
 nf=fldU.grid.nFaces
 nf==5 ? s=vcat(s,s[3]) : nothing
 tp=fldU.grid.class
-FLDU=similar(fldU)
-FLDV=similar(fldV)
+FLDU=similar(fldU;m=fldU.meta)
+FLDV=similar(fldV;m=fldV.meta)
 
 for i=1:nf
   FLDU.f[i]=fill(fillval,s[i][1]+1,s[i][2]);

--- a/src/Exchanges.jl
+++ b/src/Exchanges.jl
@@ -44,7 +44,7 @@ elseif fld.grid.class=="PeriodicChanel"
 elseif fld.grid.class=="PeriodicDomain"
   FLD=exch_T_N_dpdo(fld,N)
 else
-  error("unknown grTopo case")
+  error("unknown grid.class case")
 end
 
 return FLD
@@ -62,7 +62,7 @@ elseif u.grid.class=="PeriodicChanel"
 elseif u.grid.class=="PeriodicDomain"
   (uex,vex)=exch_UV_N_dpdo(u,v,N)
 else
-  error("unknown grTopo case")
+  error("unknown grid.class case")
 end
 
 return uex,vex
@@ -80,7 +80,7 @@ elseif u.grid.class=="PeriodicChanel"
 elseif u.grid.class=="PeriodicDomain"
   (uex,vex)=exch_UV_dpdo(u,v)
 else
-  error("unknown grTopo case")
+  error("unknown grid.class case")
 end
 
 return uex,vex

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -44,18 +44,16 @@ else
     error("unknown GridName case")
 end
 
-mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, read, write)
-
-return mygrid
+return gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, read, write)
 
 end
 
 ## GridLoad function
 
 """
-    GridLoad(mygrid::gcmgrid)
+    GridLoad(γ::gcmgrid)
 
-Return a `Dict` of grid variables read from files located in `mygrid.path` (see `?GridSpec`).
+Return a `Dict` of grid variables read from files located in `γ.path` (see `?GridSpec`).
 
 Based on the MITgcm naming convention, grid variables are:
 
@@ -63,47 +61,47 @@ Based on the MITgcm naming convention, grid variables are:
 - RAC, RAW, RAS, RAZ, DXC, DXG, DYC, DYG.
 - DRC, DRF, RC, RF (one-dimensional)
 """
-function GridLoad(mygrid::gcmgrid)
+function GridLoad(γ::gcmgrid)
 
-    GridVariables=Dict()
+    Γ=Dict()
 
     list0=("XC","XG","YC","YG","AngleCS","AngleSN","RAC","RAW","RAS","RAZ",
     "DXC","DXG","DYC","DYG","Depth")
     for ii=1:length(list0)
-        tmp1=mygrid.read(mygrid.path*list0[ii]*".data",MeshArray(mygrid,mygrid.ioPrec))
+        tmp1=γ.read(γ.path*list0[ii]*".data",MeshArray(γ,γ.ioPrec))
         tmp2=Symbol(list0[ii])
         @eval (($tmp2) = ($tmp1))
-        GridVariables[list0[ii]]=tmp1
+        Γ[list0[ii]]=tmp1
     end
 
-    mygrid.ioPrec==Float64 ? reclen=8 : reclen=4
+    γ.ioPrec==Float64 ? reclen=8 : reclen=4
 
     list0=("DRC","DRF","RC","RF")
     for ii=1:length(list0)
-        fil=mygrid.path*list0[ii]*".data"
+        fil=γ.path*list0[ii]*".data"
         tmp1=stat(fil)
         n3=Int64(tmp1.size/reclen)
 
         fid = open(fil)
-        tmp1 = Array{mygrid.ioPrec,1}(undef,n3)
+        tmp1 = Array{γ.ioPrec,1}(undef,n3)
         read!(fid,tmp1)
         tmp1 = hton.(tmp1)
 
         tmp2=Symbol(list0[ii])
         @eval (($tmp2) = ($tmp1))
-        GridVariables[list0[ii]]=tmp1
+        Γ[list0[ii]]=tmp1
     end
 
     list0=("hFacC","hFacS","hFacW")
-    n3=length(GridVariables["RC"])
+    n3=length(Γ["RC"])
     for ii=1:length(list0)
-        tmp1=mygrid.read(mygrid.path*list0[ii]*".data",MeshArray(mygrid,mygrid.ioPrec,n3))
+        tmp1=γ.read(γ.path*list0[ii]*".data",MeshArray(γ,γ.ioPrec,n3))
         tmp2=Symbol(list0[ii])
         @eval (($tmp2) = ($tmp1))
-        GridVariables[list0[ii]]=tmp1
+        Γ[list0[ii]]=tmp1
     end
 
-    return GridVariables
+    return Γ
 
 end
 
@@ -135,34 +133,34 @@ function GridOfOnes(grTp,nF,nP)
     facesSize[:].=[(nP,nP)]
     ioPrec=Float32
 
-    mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, read, write)
+    γ=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, read, write)
 
-    GridVariables=Dict()
+    Γ=Dict()
     list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");
     for ii=1:length(list0);
         tmp1=fill(1.,nP,nP*nF);
-        tmp1=mygrid.read(tmp1,MeshArray(mygrid,Float64));
+        tmp1=γ.read(tmp1,MeshArray(γ,Float64));
         tmp2=Symbol(list0[ii]);
         @eval (($tmp2) = ($tmp1))
-        GridVariables[list0[ii]]=tmp1
+        Γ[list0[ii]]=tmp1
     end
 
-    return mygrid, GridVariables
+    return γ, Γ
 
 end
 
 """
-    TileMap(ni::Int,nj::Int,mygrid::gcmgrid)
+    TileMap(ni::Int,nj::Int,γ::gcmgrid)
 
 Return a `MeshArray` map of tile indices for tile size `ni,nj`
 """
-function TileMap(mygrid::gcmgrid,ni::Int,nj::Int)
-    nbr=MeshArray(mygrid)
+function TileMap(γ::gcmgrid,ni::Int,nj::Int)
+    nbr=MeshArray(γ)
     #
     cnt=0
-    for iF=1:mygrid.nFaces
-        for jj=Int.(1:mygrid.fSize[iF][2]/nj)
-            for ii=Int.(1:mygrid.fSize[iF][1]/ni)
+    for iF=1:γ.nFaces
+        for jj=Int.(1:γ.fSize[iF][2]/nj)
+            for ii=Int.(1:γ.fSize[iF][1]/ni)
                 cnt=cnt+1
                 tmp_i=(1:ni).+ni*(ii-1)
                 tmp_j=(1:nj).+nj*(jj-1)
@@ -175,20 +173,20 @@ function TileMap(mygrid::gcmgrid,ni::Int,nj::Int)
 end
 
 """
-    GridAddWS!(GridVariables::Dict)
+    GridAddWS!(Γ::Dict)
 
 Compute XW, YW, XS, and YS (vector field locations) from XC, YC (tracer
-field locations) and add them to GridVariables.
+field locations) and add them to Γ.
 
 ```
-GridVariables=GridLoad(GridSpec("LatLonCap","GRID_LLC90/"))
-GridAddWS!(GridVariables)
+Γ=GridLoad(GridSpec("LatLonCap","GRID_LLC90/"))
+GridAddWS!(Γ)
 ```
 """
-function GridAddWS!(GridVariables::Dict)
+function GridAddWS!(Γ::Dict)
 
-    XC=exchange(GridVariables["XC"])
-    YC=exchange(GridVariables["YC"])
+    XC=exchange(Γ["XC"])
+    YC=exchange(Γ["YC"])
     nFaces=XC.grid.nFaces
     XW=NaN .* XC; YW=NaN .* YC; XS=NaN .* XC; YS=NaN .* YC;
 
@@ -220,9 +218,9 @@ function GridAddWS!(GridVariables::Dict)
     XW[findall(XW.<Xmin)]=XW[findall(XW.<Xmin)].+360;
     XW[findall(XW.>Xmax)]=XW[findall(XW.>Xmax)].-360;
 
-    GridVariables["XW"]=XW
-    GridVariables["XS"]=XS
-    GridVariables["YW"]=YW
-    GridVariables["YS"]=YS
-    return GridVariables
+    Γ["XW"]=XW
+    Γ["XS"]=XS
+    Γ["YW"]=YW
+    Γ["YS"]=YS
+    return Γ
 end

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -110,7 +110,11 @@ end
 """
     GridOfOnes(grTp,nF,nP)
 
-Define all-ones grid variables instead of using `GridSpec` & `GridLoad`.
+Define all-ones grid variables instead of using `GridSpec` & `GridLoad`. E.g.
+
+```
+γ,Γ=GridOfOnes("CubeSphere",6,20);
+```
 """
 function GridOfOnes(grTp,nF,nP)
 
@@ -143,7 +147,7 @@ function GridOfOnes(grTp,nF,nP)
         GridVariables[list0[ii]]=tmp1
     end
 
-    return GridVariables
+    return mygrid, GridVariables
 
 end
 

--- a/src/MeshArrays.jl
+++ b/src/MeshArrays.jl
@@ -3,7 +3,7 @@
 module MeshArrays
 
 using Pkg
-version()=Pkg.TOML.parsefile(joinpath(dirname(pathof(MeshArrays)), "..", "Project.toml"))["version"]
+thisversion=Pkg.TOML.parsefile(joinpath(dirname(pathof(MeshArrays)), "..", "Project.toml"))["version"]
 
 include("Types.jl");
 include("Grids.jl");

--- a/src/MeshArrays.jl
+++ b/src/MeshArrays.jl
@@ -3,7 +3,8 @@
 module MeshArrays
 
 using Pkg
-thisversion=Pkg.TOML.parsefile(joinpath(dirname(pathof(MeshArrays)), "..", "Project.toml"))["version"]
+thistoml=joinpath(dirname(pathof(MeshArrays)), "..", "Project.toml")
+thisversion=Pkg.TOML.parsefile(thistoml)["version"]
 
 include("Types.jl");
 include("Grids.jl");

--- a/src/MeshArrays.jl
+++ b/src/MeshArrays.jl
@@ -2,6 +2,9 @@
 
 module MeshArrays
 
+using Pkg
+version()=Pkg.TOML.parsefile(joinpath(dirname(pathof(MeshArrays)), "..", "Project.toml"))["version"]
+
 include("Types.jl");
 include("Grids.jl");
 include("Operations.jl");

--- a/src/ReadWrite.jl
+++ b/src/ReadWrite.jl
@@ -33,7 +33,7 @@ function read(xx::Array,x::MeshArray)
 
   size(xx)!=(n1*n2,n3) ? xx=reshape(xx,(n1*n2,n3)) : nothing
 
-  y=similar(x)
+  y=similar(x; m=x.meta)
   i0=0; i1=0;
   for iFace=1:nFaces
     i0=i1+1;

--- a/src/ReadWrite.jl
+++ b/src/ReadWrite.jl
@@ -12,8 +12,6 @@ read(xx::Array,x::MeshArray) #from Array
 """
 function read(fil::String,x::MeshArray)
 
-  grTopo=x.grid.class
-  facesSize=x.grid.fSize
   (n1,n2)=x.grid.ioSize
   (nFaces,n3)=nFacesEtc(x)
 
@@ -29,7 +27,6 @@ end
 
 function read(xx::Array,x::MeshArray)
 
-  grTopo=x.grid.class
   facesSize=x.grid.fSize
   (n1,n2)=x.grid.ioSize
   (nFaces,n3)=nFacesEtc(x)
@@ -77,7 +74,6 @@ end
 
 function write(x::MeshArray)
 
-  grTopo=x.grid.class
   facesSize=x.grid.fSize
   (n1,n2)=x.grid.ioSize
   (nFaces,n3)=nFacesEtc(x)

--- a/src/Solvers.jl
+++ b/src/Solvers.jl
@@ -153,14 +153,14 @@ function ScalarPotential(TrspCon)
 end
 
 """
-    VectorPotential(TrspX,TrspY,GridVariables,method::Int=1)
+    VectorPotential(TrspX,TrspY,Γ,method::Int=1)
 
 Vector potential inversion.
 ```
 TrspPot=ScalarPotential(TrspCon)
 ```
 """
-function VectorPotential(TrspX::MeshArray,TrspY::MeshArray,GridVariables::Dict,method::Int=1)
+function VectorPotential(TrspX::MeshArray,TrspY::MeshArray,Γ::Dict,method::Int=1)
 
     # 1)  streamfunction face by face:
 
@@ -176,8 +176,8 @@ function VectorPotential(TrspX::MeshArray,TrspY::MeshArray,GridVariables::Dict,m
     # 2a)  reset one land value per face to zero (method 1)
 
     if method==1
-        mskW=mask(1.0 .+ 0.0 * mask(view(GridVariables["hFacW"],:,1),NaN,0.0),0.0)
-        mskS=mask(1.0 .+ 0.0 * mask(view(GridVariables["hFacS"],:,1),NaN,0.0),0.0)
+        mskW=mask(1.0 .+ 0.0 * mask(view(Γ["hFacW"],:,1),NaN,0.0),0.0)
+        mskS=mask(1.0 .+ 0.0 * mask(view(Γ["hFacS"],:,1),NaN,0.0),0.0)
         (mskW,mskS)=exch_UV(mskW,mskS); mskW=abs.(mskW); mskS=abs.(mskS)
 
         for iF=1:TrspX.grid.nFaces
@@ -253,12 +253,12 @@ function VectorPotential(TrspX::MeshArray,TrspY::MeshArray,GridVariables::Dict,m
     tmp1=write(psi)
 
     #all land points:
-    tmp2=write(view(GridVariables["hFacC"],:,1))
+    tmp2=write(view(Γ["hFacC"],:,1))
     tmp2=findall( (tmp2 .== 0.0) .& (!isnan).(tmp1))
 
     #closest to Boston:
-    tmp_lon=write(GridVariables["XC"])[tmp2]
-    tmp_lat=write(GridVariables["YC"])[tmp2]
+    tmp_lon=write(Γ["XC"])[tmp2]
+    tmp_lat=write(Γ["YC"])[tmp2]
     tmp_dis=(tmp_lat .- 42.3601).^2 + (tmp_lon .- 71.0589).^2
     tmp2=tmp2[findall(tmp_dis .== minimum(tmp_dis))]
 

--- a/src/Type_gcmarray.jl
+++ b/src/Type_gcmarray.jl
@@ -31,7 +31,7 @@ struct gcmarray{T, N} <: AbstractMeshArray{T, N}
 end
 
 function gcmarray(grid::gcmgrid,f::Array{Array{T,2},N}) where {T, N}
-  gcmarray{T,N}(grid,varmeta(),f,grid.fSize,collect(1:grid.nFaces),version())
+  gcmarray{T,N}(grid,defaultmeta,f,grid.fSize,collect(1:grid.nFaces),thisversion)
 end
 
 function gcmarray(grid::gcmgrid,f::Array{Array{T,N},1}) where {T, N}
@@ -43,9 +43,9 @@ function gcmarray(grid::gcmgrid,f::Array{Array{T,N},1}) where {T, N}
       g[I]=view(f[I[1]],:,:,I[2],I[3])
     end
     n4==1 ? g=dropdims(g,dims=3) : nothing
-    gcmarray{T,ndims(g)}(grid,varmeta(),g,grid.fSize,collect(1:nFaces),version())
+    gcmarray{T,ndims(g)}(grid,defaultmeta,g,grid.fSize,collect(1:nFaces),thisversion)
   else
-    gcmarray{T,1}(grid,varmeta(),f,grid.fSize,collect(1:nFaces),version())
+    gcmarray{T,1}(grid,defaultmeta,f,grid.fSize,collect(1:nFaces),thisversion)
   end
 end
 
@@ -59,7 +59,7 @@ function gcmarray(grid::gcmgrid,::Type{T},
   for a=1:nFaces
     f[a]=Array{T}(undef,fSize[a])
   end
-  gcmarray{T,1}(grid,varmeta(),f,fSize,fIndex,version())
+  gcmarray{T,1}(grid,defaultmeta,f,fSize,fIndex,thisversion)
 end
 
 function gcmarray(grid::gcmgrid,::Type{T},
@@ -72,7 +72,7 @@ function gcmarray(grid::gcmgrid,::Type{T},
   for a=1:nFaces; for i3=1:n3;
     f[a,i3]=Array{T}(undef,fSize[a]...)
   end; end;
-  gcmarray{T,2}(grid,varmeta(),f,fSize,fIndex,version())
+  gcmarray{T,2}(grid,defaultmeta,f,fSize,fIndex,thisversion)
 end
 
 function gcmarray(grid::gcmgrid,::Type{T},
@@ -85,7 +85,7 @@ function gcmarray(grid::gcmgrid,::Type{T},
   for a=1:nFaces; for i4=1:n4; for i3=1:n3;
     f[a,i3,i4]=Array{T}(undef,fSize[a]...)
   end; end; end;
-  gcmarray{T,3}(grid,varmeta(),f,fSize,fIndex,version())
+  gcmarray{T,3}(grid,defaultmeta,f,fSize,fIndex,thisversion)
 end
 
 # +

--- a/src/Type_gcmarray.jl
+++ b/src/Type_gcmarray.jl
@@ -206,9 +206,9 @@ end
 
 function Base.similar(A::gcmarray)
     if ndims(A)==1
-        B=gcmarray(A.grid,eltype(A),A.fSize,A.fIndex)
+        B=gcmarray(A.grid,eltype(A),A.fSize,A.fIndex; meta=A.meta)
     else
-        B=gcmarray(A.grid,eltype(A),A.fSize,A.fIndex,size(A,2))
+        B=gcmarray(A.grid,eltype(A),A.fSize,A.fIndex,size(A,2); meta=A.meta)
     end
     return B
 end

--- a/src/Type_gcmarray.jl
+++ b/src/Type_gcmarray.jl
@@ -204,11 +204,11 @@ function Base.show(io::IO, z::gcmarray{T, N}) where {T,N}
   return
 end
 
-function Base.similar(A::gcmarray)
+function Base.similar(A::gcmarray;m::varmeta=defaultmeta)
     if ndims(A)==1
-        B=gcmarray(A.grid,eltype(A),A.fSize,A.fIndex; meta=A.meta)
+        B=gcmarray(A.grid,eltype(A),A.fSize,A.fIndex; meta=m)
     else
-        B=gcmarray(A.grid,eltype(A),A.fSize,A.fIndex,size(A,2); meta=A.meta)
+        B=gcmarray(A.grid,eltype(A),A.fSize,A.fIndex,size(A,2); meta=m)
     end
     return B
 end

--- a/src/Type_gcmarray.jl
+++ b/src/Type_gcmarray.jl
@@ -5,8 +5,8 @@
 gcmarray data structure. Available constructors:
 
 ```
-gcmarray{T,N}(grid::gcmgrid,f::Array{Array{T,2},N},
-         fSize::Array{NTuple{N, Int}},fIndex::Array{Int,1})
+gcmarray{T,N}(grid::gcmgrid,meta::varmeta,f::Array{Array{T,2},N},
+         fSize::Array{NTuple{N, Int}},fIndex::Array{Int,1},v::String)
 
 gcmarray(grid::gcmgrid,f::Array{Array{T,2},N}) where {T,N}
 gcmarray(grid::gcmgrid,f::Array{Array{T,N},1}) where {T,N}
@@ -23,13 +23,15 @@ gcmarray(grid::gcmgrid,::Type{T},n3::Int,n4::Int)
 """
 struct gcmarray{T, N} <: AbstractMeshArray{T, N}
    grid::gcmgrid
+   meta::varmeta
    f::Array{Array{T,2},N}
    fSize::Array{NTuple{2, Int}}
    fIndex::Array{Int,1}
+   version::String
 end
 
 function gcmarray(grid::gcmgrid,f::Array{Array{T,2},N}) where {T, N}
-  gcmarray{T,N}(grid,f,grid.fSize,collect(1:grid.nFaces))
+  gcmarray{T,N}(grid,varmeta(),f,grid.fSize,collect(1:grid.nFaces),version())
 end
 
 function gcmarray(grid::gcmgrid,f::Array{Array{T,N},1}) where {T, N}
@@ -41,9 +43,9 @@ function gcmarray(grid::gcmgrid,f::Array{Array{T,N},1}) where {T, N}
       g[I]=view(f[I[1]],:,:,I[2],I[3])
     end
     n4==1 ? g=dropdims(g,dims=3) : nothing
-    gcmarray{T,ndims(g)}(grid,g,grid.fSize,collect(1:nFaces))
+    gcmarray{T,ndims(g)}(grid,varmeta(),g,grid.fSize,collect(1:nFaces),version())
   else
-    gcmarray{T,1}(grid,f,grid.fSize,collect(1:nFaces))
+    gcmarray{T,1}(grid,varmeta(),f,grid.fSize,collect(1:nFaces),version())
   end
 end
 
@@ -57,7 +59,7 @@ function gcmarray(grid::gcmgrid,::Type{T},
   for a=1:nFaces
     f[a]=Array{T}(undef,fSize[a])
   end
-  gcmarray{T,1}(grid,f,fSize,fIndex)
+  gcmarray{T,1}(grid,varmeta(),f,fSize,fIndex,version())
 end
 
 function gcmarray(grid::gcmgrid,::Type{T},
@@ -70,7 +72,7 @@ function gcmarray(grid::gcmgrid,::Type{T},
   for a=1:nFaces; for i3=1:n3;
     f[a,i3]=Array{T}(undef,fSize[a]...)
   end; end;
-  gcmarray{T,2}(grid,f,fSize,fIndex)
+  gcmarray{T,2}(grid,varmeta(),f,fSize,fIndex,version())
 end
 
 function gcmarray(grid::gcmgrid,::Type{T},
@@ -83,7 +85,7 @@ function gcmarray(grid::gcmgrid,::Type{T},
   for a=1:nFaces; for i4=1:n4; for i3=1:n3;
     f[a,i3,i4]=Array{T}(undef,fSize[a]...)
   end; end; end;
-  gcmarray{T,3}(grid,f,fSize,fIndex)
+  gcmarray{T,3}(grid,varmeta(),f,fSize,fIndex,version())
 end
 
 # +

--- a/src/Type_gcmarray.jl
+++ b/src/Type_gcmarray.jl
@@ -30,11 +30,13 @@ struct gcmarray{T, N} <: AbstractMeshArray{T, N}
    version::String
 end
 
-function gcmarray(grid::gcmgrid,f::Array{Array{T,2},N}) where {T, N}
-  gcmarray{T,N}(grid,defaultmeta,f,grid.fSize,collect(1:grid.nFaces),thisversion)
+function gcmarray(grid::gcmgrid,f::Array{Array{T,2},N};
+                  meta::varmeta=defaultmeta) where {T, N}
+  gcmarray{T,N}(grid,meta,f,grid.fSize,collect(1:grid.nFaces),thisversion)
 end
 
-function gcmarray(grid::gcmgrid,f::Array{Array{T,N},1}) where {T, N}
+function gcmarray(grid::gcmgrid,f::Array{Array{T,N},1};
+                  meta::varmeta=defaultmeta) where {T, N}
   nFaces=grid.nFaces
   if N>2
     n3=size(f[1],3); n4=size(f[1],4);
@@ -43,15 +45,16 @@ function gcmarray(grid::gcmgrid,f::Array{Array{T,N},1}) where {T, N}
       g[I]=view(f[I[1]],:,:,I[2],I[3])
     end
     n4==1 ? g=dropdims(g,dims=3) : nothing
-    gcmarray{T,ndims(g)}(grid,defaultmeta,g,grid.fSize,collect(1:nFaces),thisversion)
+    gcmarray{T,ndims(g)}(grid,meta,g,grid.fSize,collect(1:nFaces),thisversion)
   else
-    gcmarray{T,1}(grid,defaultmeta,f,grid.fSize,collect(1:nFaces),thisversion)
+    gcmarray{T,1}(grid,meta,f,grid.fSize,collect(1:nFaces),thisversion)
   end
 end
 
 function gcmarray(grid::gcmgrid,::Type{T},
         fSize::Union{Array{NTuple{2, Int},1},NTuple{2, Int}},
-        fIndex::Union{Array{Int,1},Int}) where {T}
+        fIndex::Union{Array{Int,1},Int};
+        meta::varmeta=defaultmeta) where {T}
   nFaces=length(fIndex)
   f=Array{Array{T,2},1}(undef,nFaces)
   isa(fSize,NTuple) ? fSize=[fSize] : nothing
@@ -59,12 +62,13 @@ function gcmarray(grid::gcmgrid,::Type{T},
   for a=1:nFaces
     f[a]=Array{T}(undef,fSize[a])
   end
-  gcmarray{T,1}(grid,defaultmeta,f,fSize,fIndex,thisversion)
+  gcmarray{T,1}(grid,meta,f,fSize,fIndex,thisversion)
 end
 
 function gcmarray(grid::gcmgrid,::Type{T},
         fSize::Union{Array{NTuple{2, Int},1},NTuple{2, Int}},
-        fIndex::Union{Array{Int,1},Int},n3::Int) where {T}
+        fIndex::Union{Array{Int,1},Int},n3::Int;
+        meta::varmeta=defaultmeta) where {T}
   nFaces=length(fIndex)
   f=Array{Array{T,2},2}(undef,nFaces,n3)
   isa(fSize,NTuple) ? fSize=[fSize] : nothing
@@ -72,12 +76,13 @@ function gcmarray(grid::gcmgrid,::Type{T},
   for a=1:nFaces; for i3=1:n3;
     f[a,i3]=Array{T}(undef,fSize[a]...)
   end; end;
-  gcmarray{T,2}(grid,defaultmeta,f,fSize,fIndex,thisversion)
+  gcmarray{T,2}(grid,meta,f,fSize,fIndex,thisversion)
 end
 
 function gcmarray(grid::gcmgrid,::Type{T},
         fSize::Union{Array{NTuple{2, Int},1},NTuple{2, Int}},
-        fIndex::Union{Array{Int,1},Int},n3::Int,n4::Int) where {T}
+        fIndex::Union{Array{Int,1},Int},n3::Int,n4::Int;
+        meta::varmeta=defaultmeta) where {T}
   nFaces=length(fIndex)
   f=Array{Array{T,2},3}(undef,nFaces,n3,n4)
   isa(fSize,NTuple) ? fSize=[fSize] : nothing
@@ -85,37 +90,40 @@ function gcmarray(grid::gcmgrid,::Type{T},
   for a=1:nFaces; for i4=1:n4; for i3=1:n3;
     f[a,i3,i4]=Array{T}(undef,fSize[a]...)
   end; end; end;
-  gcmarray{T,3}(grid,defaultmeta,f,fSize,fIndex,thisversion)
+  gcmarray{T,3}(grid,meta,f,fSize,fIndex,thisversion)
 end
 
 # +
-function gcmarray(grid::gcmgrid)
+function gcmarray(grid::gcmgrid; meta::varmeta=defaultmeta)
   nFaces=grid.nFaces
   fSize=grid.fSize
   fIndex=collect(1:grid.nFaces)
   T=grid.ioPrec
-  gcmarray(grid,T,fSize,fIndex)
+  gcmarray(grid,T,fSize,fIndex,meta=meta)
 end
 
-function gcmarray(grid::gcmgrid,::Type{T}) where {T}
+function gcmarray(grid::gcmgrid,::Type{T};
+                  meta::varmeta=defaultmeta) where {T}
   nFaces=grid.nFaces
   fSize=grid.fSize
   fIndex=collect(1:grid.nFaces)
-  gcmarray(grid,T,fSize,fIndex)
+  gcmarray(grid,T,fSize,fIndex,meta=meta)
 end
 
-function gcmarray(grid::gcmgrid,::Type{T},n3::Int) where {T}
+function gcmarray(grid::gcmgrid,::Type{T},n3::Int;
+                  meta::varmeta=defaultmeta) where {T}
   nFaces=grid.nFaces
   fSize=grid.fSize
   fIndex=collect(1:grid.nFaces)
-  gcmarray(grid,T,fSize,fIndex,n3)
+  gcmarray(grid,T,fSize,fIndex,n3,meta=meta)
 end
 
-function gcmarray(grid::gcmgrid,::Type{T},n3::Int,n4::Int) where {T}
+function gcmarray(grid::gcmgrid,::Type{T},n3::Int,n4::Int;
+                  meta::varmeta=defaultmeta) where {T}
   nFaces=grid.nFaces
   fSize=grid.fSize
   fIndex=collect(1:grid.nFaces)
-  gcmarray(grid,T,fSize,fIndex,n3,n4)
+  gcmarray(grid,T,fSize,fIndex,n3,n4,meta=meta)
 end
 
 # -

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -37,16 +37,18 @@ end
 varmeta data structure. Available constructors:
 
 ```
-varmeta(name::String,unit::Union{Unitful.AbstractQuantity,Number})
-varmeta() = varmeta("unknown",1.0)
+varmeta(name::String,unit::Union{Unitful.AbstractQuantity,Number},
+        position::Array{Float64,1})
+varmeta() = varmeta("unknown",1.0,fill(0.5,3))
 ```
 """
 struct varmeta
   name::String
   unit::Union{Unitful.AbstractQuantity,Number}
+  position::Array{Float64,1}
 end
 
-varmeta() = varmeta("unknown",1.0)
+varmeta() = varmeta("unknown",1.0,fill(0.5,3))
 
 ## concrete types and MeshArray alias:
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1,4 +1,6 @@
 
+using Unitful
+
 """
     AbstractMeshArray{T, N}
 
@@ -28,6 +30,23 @@ struct gcmgrid
   read::Function
   write::Function
 end
+
+"""
+    varmeta
+
+varmeta data structure. Available constructors:
+
+```
+varmeta(name::String,unit::Union{Unitful.AbstractQuantity,Number})
+varmeta() = varmeta("unknown",1.0)
+```
+"""
+struct varmeta
+  name::String
+  unit::Union{Unitful.AbstractQuantity,Number}
+end
+
+varmeta() = varmeta("unknown",1.0)
 
 ## concrete types and MeshArray alias:
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -34,21 +34,29 @@ end
 """
     varmeta
 
-varmeta data structure. Available constructors:
+varmeta data structure. By default, `unit` is `1.0` (non-dimensional), `position`
+is `fill(0.5,3)` (cell center), and `name` / `long_name` is unknown.
+
+Available constructors:
 
 ```
-varmeta(name::String,unit::Union{Unitful.AbstractQuantity,Number},
-        position::Array{Float64,1})
-varmeta() = varmeta("unknown",1.0,fill(0.5,3))
+varmeta(unit::Union{Unitful.AbstractQuantity,Number},position::Array{Float64,1},
+        name::String,long_name::String)
 ```
+
+And:
+
+```defaultmeta = varmeta(1.0,fill(0.5,3),"unknown","unknown")```
+
 """
 struct varmeta
-  name::String
   unit::Union{Unitful.Units,Number}
   position::Array{Float64,1}
+  name::String
+  long_name::String
 end
 
-defaultmeta = varmeta("unknown",1.0,fill(0.5,3))
+defaultmeta = varmeta(1.0,fill(0.5,3),"unknown","unknown")
 
 ## concrete types and MeshArray alias:
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -50,13 +50,13 @@ And:
 
 """
 struct varmeta
-  unit::Union{Unitful.Units,Number}
+  unit::Union{Unitful.Units,Number,Missing}
   position::Array{Float64,1}
   name::String
   long_name::String
 end
 
-defaultmeta = varmeta(1.0,fill(0.5,3),"unknown","unknown")
+defaultmeta = varmeta(missing,fill(0.5,3),"unknown","unknown")
 
 ## concrete types and MeshArray alias:
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -44,7 +44,7 @@ varmeta() = varmeta("unknown",1.0,fill(0.5,3))
 """
 struct varmeta
   name::String
-  unit::Union{Unitful.AbstractQuantity,Number}
+  unit::Union{Unitful.Units,Number}
   position::Array{Float64,1}
 end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -48,7 +48,7 @@ struct varmeta
   position::Array{Float64,1}
 end
 
-varmeta() = varmeta("unknown",1.0,fill(0.5,3))
+defaultmeta = varmeta("unknown",1.0,fill(0.5,3))
 
 ## concrete types and MeshArray alias:
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,11 +11,10 @@ for nTopo=1:3
     elseif nTopo==3; grTopo="PeriodicChanel"; nFaces=1; N=500;
     end;
     Npt=nFaces*N*N
-    GridVariables=GridOfOnes(grTopo,nFaces,N)
-    mygrid=GridVariables["XC"].grid
-    @test mygrid.class == grTopo
+    γ,Γ=GridOfOnes(grTopo,nFaces,N)
+    @test γ.class == grTopo
     Rini= 0.; Rend= 0.;
-    (Rini,Rend,DXCsm,DYCsm)=demo2(GridVariables);
+    (Rini,Rend,DXCsm,DYCsm)=demo2(Γ);
     @test isa(Rend,MeshArray)
     @test sum(isfinite.(Rend)) == Npt
     Sini=sqrt(sum(Rini*Rini)/(Npt-1.0))


### PR DESCRIPTION
- added dependency to `Unitful.jl` via `varmeta` data structure
- `defaultmeta = varmeta(missing,fill(0.5,3),"unknown","unknown")`
- support for non-default `varmeta` is limited to constructors, `similar`, `read` and `exchange`
- `GridLoad` & `GridOfOnes` add meta data for grid variables
- rename `mygrid,GridVariables` as `γ,Γ`
- `GridOfOnes` now returns both `γ,Γ`
