### PR TITLE
add support for LLC270 grid

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -14,6 +14,15 @@ lazy = true
     sha256 = "90d5e4a07014e7958e4ec6d461fa78fa72d81d09589a8b951cd392dd74ecc7cb"
     url = "https://github.com/gaelforget/GRID_LL360/archive/v1.0.tar.gz"
 
+[GRID_LLC270]
+#git-tree-sha1 = "7ccfbaa17e91bdbd2d585a9aea466469168b3bd5"
+git-tree-sha1 = "1bc43784dfbcb787cc4e8018ab61d5c3cdcd5ea3"
+lazy = true
+
+    [[GRID_LLC270.download]]
+    sha256 = "c5b44a7afd463a480d370a8577edecf36a93ff099447c8052faf44c091096544"
+    url = "https://zenodo.org/records/15352381/files/GRID_LLC270-1.0.0.tar.gz"
+
 [GRID_LLC90]
 git-tree-sha1 = "0a62225e81fc22f37aefcf57465676c4cc934b11"
 lazy = true

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -31,7 +31,7 @@ land_mask(Γ::NamedTuple)=land_mask(Γ.hFacC[:,1])
 ## GridSpec function with category argument:
 
 """
-    GridSpec(category="PeriodicDomain",path=tempname(); ny=nothing, ID=:unknown)
+    GridSpec(category="PeriodicDomain",path=tempname(); np=nothing, ID=:unknown)
 
 - Select one of the pre-defined grids either by ID (keyword) or by category.
 - Return the corresponding `gcmgrid` specification, including the path where grid files can be accessed (`path`).
@@ -75,17 +75,17 @@ isa(g,gcmgrid)
 true
 ```
 
-3. by `category` and `path` with the `ny` argument
-- `ny` is the number of grid points in y for the `LatLonCap` and `CubeSphere` tiles. 
-`ny` defaults to 90 for `LatLonCap` and 32 for `CubeSphere`, and so must be included to access the LLC270 grid.
+3. by `category` and `path` with the `np` argument
+- `np` is the number of grid points in x or y for the `LatLonCap` and `CubeSphere` tiles. 
+`np` defaults to 90 for `LatLonCap` and 32 for `CubeSphere`, and so must be included to access the LLC270 grid with the category argument.
 
 Examples:
 
 ```jldoctest; output = false
 using MeshArrays
-g = GridSpec("LatLonCap",MeshArrays.GRID_LLC90,ny=90)
-g = GridSpec("LatLonCap",MeshArrays.GRID_LLC270,ny=270)
-g = GridSpec("CubeSphere",MeshArrays.GRID_CS32,ny=32)
+g = GridSpec("LatLonCap",MeshArrays.GRID_LLC90,np=90)
+g = GridSpec("LatLonCap",MeshArrays.GRID_LLC270,np=270)
+g = GridSpec("CubeSphere",MeshArrays.GRID_CS32,np=32)
 isa(g,gcmgrid)
 
 # output
@@ -93,15 +93,15 @@ isa(g,gcmgrid)
 true
 ```
 """
-function GridSpec(category="PeriodicDomain", path=tempname(); ny=nothing, ID=:unknown)
+function GridSpec(category="PeriodicDomain", path=tempname(); np=nothing, ID=:unknown)
 
 if category=="LatLonCap"
     nFaces=5
     grTopo="LatLonCap"
-    ny === nothing ? ny=90 : ny
-    ioSize=[ny ny*13]
-    facesSize=[(ny, ny*3), (ny, ny*3), (ny, ny), (ny*3, ny), (ny*3, ny)]
-    if ny==270
+    np === nothing ? np=90 : np
+    ioSize=[np np*13]
+    facesSize=[(np, np*3), (np, np*3), (np, np), (np*3, np), (np*3, np)]
+    if np==270
         ioPrec=Float32
     else
         ioPrec=Float64
@@ -109,9 +109,9 @@ if category=="LatLonCap"
 elseif category=="CubeSphere"
     nFaces=6
     grTopo="CubeSphere"
-    ny === nothing ? ny=32 : ny
-    ioSize=[ny ny*nFaces]
-    facesSize=[(ny, ny), (ny, ny), (ny, ny), (ny, ny), (ny, ny), (ny, ny)]
+    np === nothing ? np=32 : np
+    ioSize=[np np*nFaces]
+    facesSize=[(np, np), (np, np), (np, np), (np, np), (np, np), (np, np)]
     ioPrec=Float32
 elseif category=="PeriodicChannel"
     nFaces=1
@@ -132,14 +132,14 @@ end
 if ID==:unknown
     gcmgrid(path, grTopo, nFaces, facesSize, ioSize, ioPrec, read, write)
 elseif ID==:LLC90
-    ny = 90
-    GridSpec("LatLonCap", MeshArrays.GRID_LLC90, ny=ny)
+    np = 90
+    GridSpec("LatLonCap", MeshArrays.GRID_LLC90, np=np)
 elseif ID==:LLC270
-    ny = 270
-    GridSpec("LatLonCap", MeshArrays.GRID_LLC270, ny=ny)
+    np = 270
+    GridSpec("LatLonCap", MeshArrays.GRID_LLC270, np=np)
 elseif ID==:CS32
-    ny = 32
-    GridSpec("CubeSphere", MeshArrays.GRID_CS32, ny=ny)
+    np = 32
+    GridSpec("CubeSphere", MeshArrays.GRID_CS32, np=np)
 elseif ID==:onedegree
     GridSpec("PeriodicChannel", MeshArrays.GRID_LL360)
 elseif ID==:default

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -2,6 +2,9 @@
 GRID_LLC90_hash = artifact_hash("GRID_LLC90", artifact_toml)
 GRID_LLC90 = joinpath(artifact_path(GRID_LLC90_hash)*"/","GRID_LLC90-1.1/")
 GRID_LLC90_download() = artifact"GRID_LLC90"
+GRID_LLC270_hash = artifact_hash("GRID_LLC270", artifact_toml)
+GRID_LLC270 = joinpath(artifact_path(GRID_LLC270_hash)*"/","GRID_LLC270-1.0.0/")
+GRID_LLC270_download() = artifact"GRID_LLC270"
 GRID_LL360_hash = artifact_hash("GRID_LL360", artifact_toml)
 GRID_LL360 = joinpath(artifact_path(GRID_LL360_hash)*"/","GRID_LL360-1.0/")
 GRID_LL360_download() = artifact"GRID_LL360"
@@ -28,7 +31,7 @@ land_mask(Γ::NamedTuple)=land_mask(Γ.hFacC[:,1])
 ## GridSpec function with category argument:
 
 """
-    GridSpec(category="PeriodicDomain",path=tempname(); ID=:unknown)
+    GridSpec(category="PeriodicDomain",path=tempname(), nx=nothing; ID=:unknown)
 
 - Select one of the pre-defined grids either by ID (keyword) or by category.
 - Return the corresponding `gcmgrid` specification, including the path where grid files can be accessed (`path`).
@@ -71,19 +74,23 @@ isa(g,gcmgrid)
 true
 ```
 """
-function GridSpec(category="PeriodicDomain",path=tempname(); ID=:unknown)
+function GridSpec(category="PeriodicDomain", path=tempname(), nx=90; ID=:unknown)
 
 if category=="LatLonCap"
     nFaces=5
     grTopo="LatLonCap"
-    ioSize=[90 1170]
-    facesSize=[(90, 270), (90, 270), (90, 90), (270, 90), (270, 90)]
-    ioPrec=Float64
+    ioSize=[nx nx*13]
+    facesSize=[(nx, nx*3), (nx, nx*3), (nx, nx), (nx*3, nx), (nx*3, nx)]
+    if nx==270
+        ioPrec=Float32
+    else
+        ioPrec=Float64
+    end
 elseif category=="CubeSphere"
     nFaces=6
     grTopo="CubeSphere"
-    ioSize=[32 192]
-    facesSize=[(32, 32), (32, 32), (32, 32), (32, 32), (32, 32), (32, 32)]
+    ioSize=[nx nx*nFaces]
+    facesSize=[(nx, nx), (nx, nx), (nx, nx), (nx, nx), (nx, nx), (nx, nx)]
     ioPrec=Float32
 elseif category=="PeriodicChannel"
     nFaces=1
@@ -102,13 +109,18 @@ else
 end
 
 if ID==:unknown
-    gcmgrid(path,grTopo,nFaces,facesSize, ioSize, ioPrec, read, write)
+    gcmgrid(path, grTopo, nFaces, facesSize, ioSize, ioPrec, read, write)
 elseif ID==:LLC90
-    GridSpec("LatLonCap",MeshArrays.GRID_LLC90)
+    nx = 90
+    GridSpec("LatLonCap", MeshArrays.GRID_LLC90, nx)
+elseif ID==:LLC270
+    nx=270
+    GridSpec("LatLonCap", MeshArrays.GRID_LLC270, nx)
 elseif ID==:CS32
-    GridSpec("CubeSphere",MeshArrays.GRID_CS32)
+    nx=32
+    GridSpec("CubeSphere", MeshArrays.GRID_CS32, nx)
 elseif ID==:onedegree
-    GridSpec("PeriodicChannel",MeshArrays.GRID_LL360)
+    GridSpec("PeriodicChannel", MeshArrays.GRID_LL360)
 elseif ID==:default
     GridSpec()
 else
@@ -156,6 +168,7 @@ function GridLoad(γ=GridSpec(); ID=:default, option=:minimal)
 
     gr.path==GRID_CS32 ? GRID_CS32_download() : nothing
     gr.path==GRID_LL360 ? GRID_LL360_download() : nothing
+    gr.path==GRID_LLC270 ? GRID_LLC270_download() : nothing
     gr.path==GRID_LLC90 ? GRID_LLC90_download() : nothing
 
     Γ=Dict()

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -31,7 +31,7 @@ land_mask(Γ::NamedTuple)=land_mask(Γ.hFacC[:,1])
 ## GridSpec function with category argument:
 
 """
-    GridSpec(category="PeriodicDomain",path=tempname(), nx=nothing; ID=:unknown)
+    GridSpec(category="PeriodicDomain",path=tempname(); ny=nothing, ID=:unknown)
 
 - Select one of the pre-defined grids either by ID (keyword) or by category.
 - Return the corresponding `gcmgrid` specification, including the path where grid files can be accessed (`path`).
@@ -40,6 +40,7 @@ land_mask(Γ::NamedTuple)=land_mask(Γ.hFacC[:,1])
 
 - `:LLC90`
 - `:CS32`
+- `:LLC270`
 - `:onedegree`
 - `:default`
 
@@ -73,16 +74,34 @@ isa(g,gcmgrid)
 
 true
 ```
+
+3. by `category` and `path` with the `ny` argument
+- `ny` is the number of grid points in y for the `LatLonCap` and `CubeSphere` tiles. 
+`ny` defaults to 90 for `LatLonCap` and 32 for `CubeSphere`, and so must be included to access the LLC270 grid.
+
+Examples:
+
+```jldoctest; output = false
+using MeshArrays
+g = GridSpec("LatLonCap",MeshArrays.GRID_LLC90,ny=90)
+g = GridSpec("LatLonCap",MeshArrays.GRID_LLC270,ny=270)
+g = GridSpec("CubeSphere",MeshArrays.GRID_CS32,ny=32)
+isa(g,gcmgrid)
+
+# output
+
+true
+```
 """
-function GridSpec(category="PeriodicDomain", path=tempname(); nx=nothing, ID=:unknown)
+function GridSpec(category="PeriodicDomain", path=tempname(); ny=nothing, ID=:unknown)
 
 if category=="LatLonCap"
     nFaces=5
     grTopo="LatLonCap"
-    nx === nothing ? nx=90 : nx
-    ioSize=[nx nx*13]
-    facesSize=[(nx, nx*3), (nx, nx*3), (nx, nx), (nx*3, nx), (nx*3, nx)]
-    if nx==270
+    ny === nothing ? ny=90 : ny
+    ioSize=[ny ny*13]
+    facesSize=[(ny, ny*3), (ny, ny*3), (ny, ny), (ny*3, ny), (ny*3, ny)]
+    if ny==270
         ioPrec=Float32
     else
         ioPrec=Float64
@@ -90,9 +109,9 @@ if category=="LatLonCap"
 elseif category=="CubeSphere"
     nFaces=6
     grTopo="CubeSphere"
-    nx === nothing ? nx=32 : nx
-    ioSize=[nx nx*nFaces]
-    facesSize=[(nx, nx), (nx, nx), (nx, nx), (nx, nx), (nx, nx), (nx, nx)]
+    ny === nothing ? ny=32 : ny
+    ioSize=[ny ny*nFaces]
+    facesSize=[(ny, ny), (ny, ny), (ny, ny), (ny, ny), (ny, ny), (ny, ny)]
     ioPrec=Float32
 elseif category=="PeriodicChannel"
     nFaces=1
@@ -113,14 +132,14 @@ end
 if ID==:unknown
     gcmgrid(path, grTopo, nFaces, facesSize, ioSize, ioPrec, read, write)
 elseif ID==:LLC90
-    nx = 90
-    GridSpec("LatLonCap", MeshArrays.GRID_LLC90, nx=nx)
+    ny = 90
+    GridSpec("LatLonCap", MeshArrays.GRID_LLC90, ny=ny)
 elseif ID==:LLC270
-    nx = 270
-    GridSpec("LatLonCap", MeshArrays.GRID_LLC270, nx=nx)
+    ny = 270
+    GridSpec("LatLonCap", MeshArrays.GRID_LLC270, ny=ny)
 elseif ID==:CS32
-    nx = 32
-    GridSpec("CubeSphere", MeshArrays.GRID_CS32, nx=nx)
+    ny = 32
+    GridSpec("CubeSphere", MeshArrays.GRID_CS32, ny=ny)
 elseif ID==:onedegree
     GridSpec("PeriodicChannel", MeshArrays.GRID_LL360)
 elseif ID==:default

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -74,11 +74,12 @@ isa(g,gcmgrid)
 true
 ```
 """
-function GridSpec(category="PeriodicDomain", path=tempname(), nx=90; ID=:unknown)
+function GridSpec(category="PeriodicDomain", path=tempname(); nx=nothing, ID=:unknown)
 
 if category=="LatLonCap"
     nFaces=5
     grTopo="LatLonCap"
+    nx === nothing ? nx=90 : nx
     ioSize=[nx nx*13]
     facesSize=[(nx, nx*3), (nx, nx*3), (nx, nx), (nx*3, nx), (nx*3, nx)]
     if nx==270
@@ -89,6 +90,7 @@ if category=="LatLonCap"
 elseif category=="CubeSphere"
     nFaces=6
     grTopo="CubeSphere"
+    nx === nothing ? nx=32 : nx
     ioSize=[nx nx*nFaces]
     facesSize=[(nx, nx), (nx, nx), (nx, nx), (nx, nx), (nx, nx), (nx, nx)]
     ioPrec=Float32
@@ -112,13 +114,13 @@ if ID==:unknown
     gcmgrid(path, grTopo, nFaces, facesSize, ioSize, ioPrec, read, write)
 elseif ID==:LLC90
     nx = 90
-    GridSpec("LatLonCap", MeshArrays.GRID_LLC90, nx)
+    GridSpec("LatLonCap", MeshArrays.GRID_LLC90, nx=nx)
 elseif ID==:LLC270
-    nx=270
-    GridSpec("LatLonCap", MeshArrays.GRID_LLC270, nx)
+    nx = 270
+    GridSpec("LatLonCap", MeshArrays.GRID_LLC270, nx=nx)
 elseif ID==:CS32
-    nx=32
-    GridSpec("CubeSphere", MeshArrays.GRID_CS32, nx)
+    nx = 32
+    GridSpec("CubeSphere", MeshArrays.GRID_CS32, nx=nx)
 elseif ID==:onedegree
     GridSpec("PeriodicChannel", MeshArrays.GRID_LL360)
 elseif ID==:default

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -169,7 +169,7 @@ end
 end
 
 @testset "gcmfaces type:" begin
-    for ID in (:CS32, :LLC270)
+    for ID in (:default, :CS32, :LLC270)
         γ=GridSpec(ID=ID)
         MeshArrays.gcmfaces(γ)
         MeshArrays.gcmfaces(γ,Float32)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ import DataDeps, JLD2, Shapefile, GeoJSON, Proj
 
 MeshArrays.GRID_LL360_download()
 MeshArrays.GRID_LLC90_download()
+MeshArrays.GRID_LLC270_download()
 MeshArrays.GRID_CS32_download()
 
 p=dirname(pathof(MeshArrays))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -169,59 +169,60 @@ end
 end
 
 @testset "gcmfaces type:" begin
-    γ=GridSpec(ID=:CS32)
+    for ID in (:CS32, :LLC270)
+        γ=GridSpec(ID=ID)
+        MeshArrays.gcmfaces(γ)
+        MeshArrays.gcmfaces(γ,Float32)
+        tmp=MeshArrays.gcmfaces(γ,Float32,3)
+        tmp[3,1,2]=1.0
+        view(tmp,:,1,1:2)
+        MeshArrays.gcmfaces(γ,tmp.f)
+        MeshArrays.fsize(tmp)
+        MeshArrays.fsize(tmp,2)
+        MeshArrays.fsize(tmp.f)
+        MeshArrays.fsize(tmp.f,2)
+        size(tmp)
+        size(tmp,3)
+        tmp1=similar(tmp)
+        2 .*tmp1
+        findall(tmp.>0)
+        MeshArrays.nFacesEtc(tmp)
+        @suppress show(tmp)
 
-    MeshArrays.gcmfaces(γ)
-    MeshArrays.gcmfaces(γ,Float32)
-    tmp=MeshArrays.gcmfaces(γ,Float32,3)
-    tmp[3,1,2]=1.0
-    view(tmp,:,1,1:2)
-    MeshArrays.gcmfaces(γ,tmp.f)
-    MeshArrays.fsize(tmp)
-    MeshArrays.fsize(tmp,2)
-    MeshArrays.fsize(tmp.f)
-    MeshArrays.fsize(tmp.f,2)
-    size(tmp)
-    size(tmp,3)
-    tmp1=similar(tmp)
-    2 .*tmp1
-    findall(tmp.>0)
-    MeshArrays.nFacesEtc(tmp)
-    @suppress show(tmp)
+        x=tmp[1:10,1,1:2]; y=x[2]; x[3]=1.0
+        view(x,1:3,:,1)
+        MeshArrays.gcmsubset(γ,x.f,x.fSize,x.aSize,x.i,x.iSize)
+        MeshArrays.fsize(x.f)
+        MeshArrays.fsize(x.f,2)
+        size(x)
+        size(x,3)
 
-    x=tmp[1:10,1,1:2]; y=x[2]; x[3]=1.0
-    view(x,1:3,:,1)
-    MeshArrays.gcmsubset(γ,x.f,x.fSize,x.aSize,x.i,x.iSize)
-    MeshArrays.fsize(x.f)
-    MeshArrays.fsize(x.f,2)
-    size(x)
-    size(x,3)
+        MeshArrays.fijind(tmp,10)
+        MeshArrays.fsize(tmp)
+        @test isa(tmp,MeshArrays.gcmfaces)
 
-    MeshArrays.fijind(tmp,10)
-    MeshArrays.fsize(tmp)
-    @test isa(tmp,MeshArrays.gcmfaces)
+        tmp=MeshArray(γ)
+        tmp1=findall(tmp.>0)
+        tmp[tmp1]
+        tmp[tmp1].=1.0
+        size(tmp1)
+        tmp1[2]
+        view(tmp1,:)
+        @suppress show(tmp1)
+        similar(tmp1)
+        #tmp[tmp1]
 
-    tmp=MeshArray(γ)
-    tmp1=findall(tmp.>0)
-    tmp[tmp1]
-    tmp[tmp1].=1.0
-    size(tmp1)
-    tmp1[2]
-    view(tmp1,:)
-    @suppress show(tmp1)
-    similar(tmp1)
-    #tmp[tmp1]
+        @suppress show(tmp)
+        MeshArrays.getindexetc(tmp,2)
+        MeshArray(γ,tmp.f,meta=tmp.meta)
+        MeshArray(γ,meta=tmp.meta)
+        MeshArray(γ,Float32,3,4)
+        MeshArray(γ,Float32,tmp.fSize,tmp.fIndex,2,3)
 
-    @suppress show(tmp)
-    MeshArrays.getindexetc(tmp,2)
-    MeshArray(γ,tmp.f,meta=tmp.meta)
-    MeshArray(γ,meta=tmp.meta)
-    MeshArray(γ,Float32,3,4)
-    MeshArray(γ,Float32,tmp.fSize,tmp.fIndex,2,3)
-
-    tmp1=MeshArray(γ,Float32,3)
-    MeshArray(γ,tmp1.f,meta=tmp1.meta)
-    MeshArrays.getindexetc(tmp1,2,1)
+        tmp1=MeshArray(γ,Float32,3)
+        MeshArray(γ,tmp1.f,meta=tmp1.meta)
+        MeshArrays.getindexetc(tmp1,2,1)
+    end
 end
 
 @testset "UnitGrid:" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,7 @@ include(joinpath(p,"../examples/Demos.jl"))
 end
 
 @testset "Vertical Dimension:" begin
-    γ=GridSpec("PeriodicChannel",MeshArrays.GRID_LL360)
+    γ=GridSpec(ID=:onedegree)
     Γ=GridLoad(γ;option="full")
     θ=Float64.(Γ.hFacC)
     nk=length(Γ.RC)


### PR DESCRIPTION
I followed the `GRID_LLC90` example to add `GridSpec` shorthand support for the LLC270 grid used by ECCO-Darwin (storing the artifact/archive file in Zenodo, rather than hosting from my own Github because the file is a little large).