### PR TITLE
Add `path` input to `interpolation_setup` to direct where to save the coefficient file...

### DIFF
--- a/src/Interpolation.jl
+++ b/src/Interpolation.jl
@@ -241,6 +241,9 @@ Download or recompute interpolation coefficients.
 
 - `λ=interpolation_setup()` to download "interp_coeffs_halfdeg.jld2" 
 - `λ=interpolation_setup(Γ=Γ)` to recompute interpolation to `lon,lat`
+- `λ=interpolation_setup(Γ=Γ,lon=lon,lat=lat,filename=filename)` to 
+    recompute interpolation to `lon,lat` and save to location and file `filename`,
+    defaulting to `tempname()*"_interp_coeffs.jld2"`.
 """
 function interpolation_setup(;Γ=NamedTuple(),
         lon=[i for i=-179.:2.0:179., j=-89.:2.0:89.],

--- a/src/Interpolation.jl
+++ b/src/Interpolation.jl
@@ -254,7 +254,8 @@ function interpolation_setup(;Γ=NamedTuple(),
                 fil=joinpath(MeshArrays.mydatadep("interp_halfdeg"),"interp_coeffs_halfdeg.jld2")
         else
 		(f,i,j,w)=InterpolationFactors(Γ,vec(lon),vec(lat))
-		MeshArrays.write_JLD2(filename; lon=lon, lat=lat, f=f, i=i, j=j, w=w)
+                fil=filename
+		MeshArrays.write_JLD2(fil; lon=lon, lat=lat, f=f, i=i, j=j, w=w)
         end
         interpolation_setup(fil)
 end

--- a/src/Interpolation.jl
+++ b/src/Interpolation.jl
@@ -244,13 +244,14 @@ Download or recompute interpolation coefficients.
 """
 function interpolation_setup(;Γ=NamedTuple(),
         lon=[i for i=-179.:2.0:179., j=-89.:2.0:89.],
-        lat=[j for i=-179.:2.0:179., j=-89.:2.0:89.])
+        lat=[j for i=-179.:2.0:179., j=-89.:2.0:89.],
+        path=tempname())
 
         if isempty(Γ)
                 fil=joinpath(MeshArrays.mydatadep("interp_halfdeg"),"interp_coeffs_halfdeg.jld2")
         else
 		(f,i,j,w)=InterpolationFactors(Γ,vec(lon),vec(lat))
-                fil=tempname()*"_interp_coeffs.jld2"
+                fil=path*"_interp_coeffs.jld2"
 		MeshArrays.write_JLD2(fil; lon=lon, lat=lat, f=f, i=i, j=j, w=w)
         end
         interpolation_setup(fil)

--- a/src/Interpolation.jl
+++ b/src/Interpolation.jl
@@ -235,7 +235,7 @@ function interpolation_setup(fil::String)
 end
 
 """
-    interpolation_setup(;Γ,lon,lat,path,url)
+    interpolation_setup(;Γ,lon,lat,filename)
     
 Download or recompute interpolation coefficients.
 
@@ -245,14 +245,13 @@ Download or recompute interpolation coefficients.
 function interpolation_setup(;Γ=NamedTuple(),
         lon=[i for i=-179.:2.0:179., j=-89.:2.0:89.],
         lat=[j for i=-179.:2.0:179., j=-89.:2.0:89.],
-        path=tempname())
+        filename=tempname()*"_interp_coeffs.jld2")
 
         if isempty(Γ)
                 fil=joinpath(MeshArrays.mydatadep("interp_halfdeg"),"interp_coeffs_halfdeg.jld2")
         else
 		(f,i,j,w)=InterpolationFactors(Γ,vec(lon),vec(lat))
-                fil=path*"_interp_coeffs.jld2"
-		MeshArrays.write_JLD2(fil; lon=lon, lat=lat, f=f, i=i, j=j, w=w)
+		MeshArrays.write_JLD2(filename; lon=lon, lat=lat, f=f, i=i, j=j, w=w)
         end
         interpolation_setup(fil)
 end


### PR DESCRIPTION
...defaults to `tempname` directory, which is the current behaviour
```julia
function interpolation_setup(;Γ=NamedTuple(),
        lon=[i for i=-179.:2.0:179., j=-89.:2.0:89.],
        lat=[j for i=-179.:2.0:179., j=-89.:2.0:89.],
        path=tempname())
```